### PR TITLE
[Entity] 즐겨찾기, 카드뉴스 관련 엔티티 생성

### DIFF
--- a/plotting/src/main/java/com/plotting/server/cardnews/application/CardnewsService.java
+++ b/plotting/src/main/java/com/plotting/server/cardnews/application/CardnewsService.java
@@ -1,0 +1,4 @@
+package com.plotting.server.cardnews.application;
+
+public class CardnewsService {
+}

--- a/plotting/src/main/java/com/plotting/server/cardnews/domain/Card.java
+++ b/plotting/src/main/java/com/plotting/server/cardnews/domain/Card.java
@@ -1,0 +1,32 @@
+package com.plotting.server.cardnews.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "card")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Card {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "card_image_url", nullable = false)
+    private String cardImageUrl;
+
+    @JoinColumn(name = "cardnews_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Cardnews cardnews;
+
+    @Builder
+    public Card(String cardImageUrl, Cardnews cardnews) {
+        this.cardImageUrl = cardImageUrl;
+        this.cardnews = cardnews;
+    }
+}

--- a/plotting/src/main/java/com/plotting/server/cardnews/domain/Cardnews.java
+++ b/plotting/src/main/java/com/plotting/server/cardnews/domain/Cardnews.java
@@ -1,0 +1,34 @@
+package com.plotting.server.cardnews.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Table(name = "cardnews")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Cardnews {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @OneToMany(mappedBy = "cardnews")
+    private List<Card> cards = new ArrayList<>();
+
+    @Builder
+    public Cardnews(String title, List<Card> cards) {
+        this.title = title;
+        this.cards = cards;
+    }
+}

--- a/plotting/src/main/java/com/plotting/server/cardnews/dto/request/CardnewsRequest.java
+++ b/plotting/src/main/java/com/plotting/server/cardnews/dto/request/CardnewsRequest.java
@@ -1,0 +1,4 @@
+package com.plotting.server.cardnews.dto.request;
+
+public record CardnewsRequest() {
+}

--- a/plotting/src/main/java/com/plotting/server/cardnews/dto/response/CardnewsResponse.java
+++ b/plotting/src/main/java/com/plotting/server/cardnews/dto/response/CardnewsResponse.java
@@ -1,6 +1,4 @@
 package com.plotting.server.cardnews.dto.response;
 
 public record CardnewsResponse() {
-    public static class CardNewsNotFoundException {
-    }
 }

--- a/plotting/src/main/java/com/plotting/server/cardnews/dto/response/CardnewsResponse.java
+++ b/plotting/src/main/java/com/plotting/server/cardnews/dto/response/CardnewsResponse.java
@@ -1,0 +1,6 @@
+package com.plotting.server.cardnews.dto.response;
+
+public record CardnewsResponse() {
+    public static class CardNewsNotFoundException {
+    }
+}

--- a/plotting/src/main/java/com/plotting/server/cardnews/exception/CardNewsNotFoundException.java
+++ b/plotting/src/main/java/com/plotting/server/cardnews/exception/CardNewsNotFoundException.java
@@ -1,0 +1,9 @@
+package com.plotting.server.cardnews.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CardNewsNotFoundException extends RuntimeException {
+}

--- a/plotting/src/main/java/com/plotting/server/cardnews/presentation/CardnewsController.java
+++ b/plotting/src/main/java/com/plotting/server/cardnews/presentation/CardnewsController.java
@@ -1,0 +1,4 @@
+package com.plotting.server.cardnews.presentation;
+
+public class CardnewsController {
+}

--- a/plotting/src/main/java/com/plotting/server/cardnews/repository/CardnewsRepository.java
+++ b/plotting/src/main/java/com/plotting/server/cardnews/repository/CardnewsRepository.java
@@ -1,0 +1,4 @@
+package com.plotting.server.cardnews.repository;
+
+public interface CardnewsRepository {
+}

--- a/plotting/src/main/java/com/plotting/server/plogging/application/PloggingService.java
+++ b/plotting/src/main/java/com/plotting/server/plogging/application/PloggingService.java
@@ -1,0 +1,4 @@
+package com.plotting.server.plogging.application;
+
+public class PloggingService {
+}

--- a/plotting/src/main/java/com/plotting/server/plogging/domain/Plogging.java
+++ b/plotting/src/main/java/com/plotting/server/plogging/domain/Plogging.java
@@ -1,0 +1,18 @@
+package com.plotting.server.plogging.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "plogging")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Plogging {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+}

--- a/plotting/src/main/java/com/plotting/server/plogging/domain/PloggingStar.java
+++ b/plotting/src/main/java/com/plotting/server/plogging/domain/PloggingStar.java
@@ -1,0 +1,34 @@
+package com.plotting.server.plogging.domain;
+
+import com.plotting.server.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "plogging_star")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class PloggingStar {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @JoinColumn(name = "user_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @JoinColumn(name = "plogging_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Plogging plogging;
+
+    @Builder
+    public PloggingStar(User user, Plogging plogging) {
+        this.user = user;
+        this.plogging = plogging;
+    }
+}

--- a/plotting/src/main/java/com/plotting/server/plogging/dto/request/PloggingRequest.java
+++ b/plotting/src/main/java/com/plotting/server/plogging/dto/request/PloggingRequest.java
@@ -1,0 +1,4 @@
+package com.plotting.server.plogging.dto.request;
+
+public record PloggingRequest() {
+}

--- a/plotting/src/main/java/com/plotting/server/plogging/dto/response/PloggingResponse.java
+++ b/plotting/src/main/java/com/plotting/server/plogging/dto/response/PloggingResponse.java
@@ -1,0 +1,4 @@
+package com.plotting.server.plogging.dto.response;
+
+public record PloggingResponse() {
+}

--- a/plotting/src/main/java/com/plotting/server/plogging/exception/PloggingNotFoundException.java
+++ b/plotting/src/main/java/com/plotting/server/plogging/exception/PloggingNotFoundException.java
@@ -1,0 +1,9 @@
+package com.plotting.server.plogging.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class PloggingNotFoundException extends RuntimeException {
+}

--- a/plotting/src/main/java/com/plotting/server/plogging/presentation/PloggingController.java
+++ b/plotting/src/main/java/com/plotting/server/plogging/presentation/PloggingController.java
@@ -1,0 +1,4 @@
+package com.plotting.server.plogging.presentation;
+
+public class PloggingController {
+}

--- a/plotting/src/main/java/com/plotting/server/plogging/repository/PloggingRepository.java
+++ b/plotting/src/main/java/com/plotting/server/plogging/repository/PloggingRepository.java
@@ -1,0 +1,4 @@
+package com.plotting.server.plogging.repository;
+
+public interface PloggingRepository {
+}

--- a/plotting/src/main/java/com/plotting/server/user/application/UserService.java
+++ b/plotting/src/main/java/com/plotting/server/user/application/UserService.java
@@ -1,0 +1,4 @@
+package com.plotting.server.user.application;
+
+public class UserService {
+}

--- a/plotting/src/main/java/com/plotting/server/user/domain/User.java
+++ b/plotting/src/main/java/com/plotting/server/user/domain/User.java
@@ -1,0 +1,18 @@
+package com.plotting.server.user.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+}

--- a/plotting/src/main/java/com/plotting/server/user/domain/UserStar.java
+++ b/plotting/src/main/java/com/plotting/server/user/domain/UserStar.java
@@ -1,0 +1,33 @@
+package com.plotting.server.user.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "user_star")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class UserStar {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @JoinColumn(name = "user_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @JoinColumn(name = "star_user_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User starUser;
+
+    @Builder
+    public UserStar(User user, User starUser) {
+        this.user = user;
+        this.starUser = starUser;
+    }
+}

--- a/plotting/src/main/java/com/plotting/server/user/dto/request/UserRequest.java
+++ b/plotting/src/main/java/com/plotting/server/user/dto/request/UserRequest.java
@@ -1,0 +1,4 @@
+package com.plotting.server.user.dto.request;
+
+public record UserRequest() {
+}

--- a/plotting/src/main/java/com/plotting/server/user/dto/response/UserResponse.java
+++ b/plotting/src/main/java/com/plotting/server/user/dto/response/UserResponse.java
@@ -1,0 +1,6 @@
+package com.plotting.server.user.dto.response;
+
+public record UserResponse() {
+    public static class CardNewsNotFoundException {
+    }
+}

--- a/plotting/src/main/java/com/plotting/server/user/dto/response/UserResponse.java
+++ b/plotting/src/main/java/com/plotting/server/user/dto/response/UserResponse.java
@@ -1,6 +1,4 @@
 package com.plotting.server.user.dto.response;
 
 public record UserResponse() {
-    public static class CardNewsNotFoundException {
-    }
 }

--- a/plotting/src/main/java/com/plotting/server/user/exception/UserNotFoundException.java
+++ b/plotting/src/main/java/com/plotting/server/user/exception/UserNotFoundException.java
@@ -1,0 +1,9 @@
+package com.plotting.server.user.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class UserNotFoundException extends RuntimeException {
+}

--- a/plotting/src/main/java/com/plotting/server/user/presentation/UserController.java
+++ b/plotting/src/main/java/com/plotting/server/user/presentation/UserController.java
@@ -1,0 +1,4 @@
+package com.plotting.server.user.presentation;
+
+public class UserController {
+}

--- a/plotting/src/main/java/com/plotting/server/user/repository/UserRepository.java
+++ b/plotting/src/main/java/com/plotting/server/user/repository/UserRepository.java
@@ -1,0 +1,4 @@
+package com.plotting.server.user.repository;
+
+public interface UserRepository {
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> #1 

## 📝작업 내용
> * 유저 즐겨찾기 엔티티 생성
> * 플로깅 즐겨찾기 엔티티 생성
> * 카드뉴스 엔티티 생성
> * 카드 엔티티 생성

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/d7bd0026-ef38-45bc-8a54-7fa354682422)
![image](https://github.com/user-attachments/assets/e7797719-84fb-4aa0-af5d-d73a891fa200)


## 💬리뷰 요구사항(선택)
> 유저랑 플로깅 즐겨찾기 ManyToOne 관계 땜에 domain 만들고 id만 만들어 놓은 상태입니다! 담당하시는 분들께서 해당 부분 수정하시면 될거 같아요!!!
